### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Markdown, but for creating multiple-choice quizzes. Especially helpful if you routinely want syntax-highlighting in your question, answers, or distractors.
 
-Try a [live version (beta)](https://static.jjfoley.me/quizdown-web/) on my website.
+Try a [live version (beta)](https://beta.jjfoley.me/quizdown-web/) on my website.
 
 ## Off-line Quick-Start
 


### PR DESCRIPTION
fix: URL is wrong and mismatches the issued certificate.

https://static.jjfoley.me/quizdown-web/ needs to become https://beat.jjfoley.me/quizdown-web/

![image](https://github.com/jjfiv/quizdown/assets/14344693/a278e1cd-4d21-4f0b-bced-474e46bf0092)
